### PR TITLE
Fix decoding of BASIC auth credentials

### DIFF
--- a/jaasmine-core/src/main/java/com/logiclander/jaasmine/authentication/http/BasicHttpAuthorizor.java
+++ b/jaasmine-core/src/main/java/com/logiclander/jaasmine/authentication/http/BasicHttpAuthorizor.java
@@ -50,7 +50,7 @@ class BasicHttpAuthorizor extends BaseHttpAuthorizor {
     private List<String> getUsernamePasswordCreds(String decodedCredential) {
 
         ImmutableList.Builder<String> decodedCreds = ImmutableList.builder();
-        for (String decodedCred : decodedCredential.split(":")) {
+        for (String decodedCred : decodedCredential.split(":", 2)) {
             decodedCreds.add(decodedCred);
         }
 


### PR DESCRIPTION
The decoding process is messing up passwords that contain a ":"
character. For example,
if a username/password combination like { "user", "abcd:1234" } 
is passed in, the password is interpreted as "abcd".

This commit fixes that problem. The first colon encountered in the auth
string is the only one that's interpreted. That is, in this commit, 
the password is correctly interpreted as "abcd:1234".